### PR TITLE
fix: use min 32 password

### DIFF
--- a/Chapter 5 - Authentication & Authorization/example 2 - hapi-auth-cookie/lib/index.js
+++ b/Chapter 5 - Authentication & Authorization/example 2 - hapi-auth-cookie/lib/index.js
@@ -20,7 +20,7 @@ server.register([
         'cookie',
         {
             cookie: 'example',
-            password: 'password',
+            password: 'password-must-be-at-least-32-characters',
             isSecure: false,
             redirectTo: '/login',
             redirectOnTry: false

--- a/Chapter 5 - Authentication & Authorization/example 3 - Authentication with a third party/lib/index.js
+++ b/Chapter 5 - Authentication & Authorization/example 3 - Authentication with a third party/lib/index.js
@@ -37,7 +37,7 @@ server.register([
         'cookie',
         {
             cookie: 'example',
-            password: 'password',
+            password: 'password-must-be-at-least-32-characters',
             isSecure: false,
             redirectTo: '/login',
             redirectOnTry: false


### PR DESCRIPTION
Cookie encoding requires the password to be at least 32 characters long.

If less than 32 characters, this error is thrown:

`Error: Failed to encode cookie (example) value: Password string too short (min 32 characters required)`
